### PR TITLE
chore: add release for arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
     - '386'
     - amd64
     - arm
+    - arm64
   ignore:
     - goos: darwin
       goarch: '386'
@@ -28,8 +29,12 @@ builds:
       goarch: arm
     - goos: openbsd
       goarch: '386'
+    - goos: openbsd
+      goarch: arm64
     - goos: windows
       goarch: arm
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
This PR adds the `arm64` architecture to the goreleaser configuration.