### PR TITLE
Fixes nil param type definition

### DIFF
--- a/drpv4/resource_drp_profile_param.go
+++ b/drpv4/resource_drp_profile_param.go
@@ -74,6 +74,10 @@ func getParamSchemaType(c *Config, name string) string {
 		return "string"
 	}
 
+	if param.Schema == nil || param.Schema.(map[string]interface{})["type"] == nil {
+		return "string"
+	}
+
 	s := param.Schema.(map[string]interface{})["type"].(string)
 
 	return s

--- a/drpv4/resource_drp_profile_param_test.go
+++ b/drpv4/resource_drp_profile_param_test.go
@@ -54,6 +54,23 @@ func TestAccResourceProfileParam(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "drp_param" "%s" {
+						name = "test_nil_schema"
+						description = "Testing nil schema"
+					}
+
+					resource "drp_profile_param" "%s" {
+						profile = "global"
+						name = drp_param.%s.name
+						value = "test"
+					}
+				`, profileParamName, profileParamName, profileParamName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("drp_profile_param.%s", profileParamName), "value", "test"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "drp_param" "%s" {
 						name = "my_password"
 						description = "Password"
 						schema = {


### PR DESCRIPTION
There were some parameters without a Schema definition that was causing the provider to panic during execution. This adds the fix by checking if the returned parameter has no Schema definition and setting it to type string by default.