### PR TITLE
Type and tests fixes to drp_pool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf_version: ["0.13", "0.14", "0.15", "1.0", "1.1", "1.2", "1.3", "1.4"]
+        tf_version: ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5"]
     needs: setup-drp
     steps:
       - name: Checkout

--- a/drpv4/resource_drp_pool.go
+++ b/drpv4/resource_drp_pool.go
@@ -74,7 +74,7 @@ func resourcePool() *schema.Resource {
 				Optional:    true,
 				Description: "The pool add parameters.",
 				Elem: &schema.Schema{
-					Type: schema.TypeMap,
+					Type: schema.TypeString,
 				},
 			},
 			"add_profiles": {

--- a/drpv4/resource_drp_reservation_test.go
+++ b/drpv4/resource_drp_reservation_test.go
@@ -19,7 +19,7 @@ func TestAccResourceReservation(t *testing.T) {
 						description = "test reservation"
 						documentation = "test reservation"
 						duration = 86400
-						token = "test"
+						token = "ff:70:81:a9:78:4d"
 						subnet = "255.255.255.0"
 					}
 				`,
@@ -28,7 +28,7 @@ func TestAccResourceReservation(t *testing.T) {
 					resource.TestCheckResourceAttr("drp_reservation.test", "description", "test reservation"),
 					resource.TestCheckResourceAttr("drp_reservation.test", "documentation", "test reservation"),
 					resource.TestCheckResourceAttr("drp_reservation.test", "duration", "86400"),
-					resource.TestCheckResourceAttr("drp_reservation.test", "token", "test"),
+					resource.TestCheckResourceAttr("drp_reservation.test", "token", "ff:70:81:a9:78:4d"),
 					resource.TestCheckResourceAttr("drp_reservation.test", "subnet", "255.255.255.0"),
 				),
 			},
@@ -39,7 +39,7 @@ func TestAccResourceReservation(t *testing.T) {
 						description = "test reservation"
 						documentation = "test reservation"
 						duration = 86400
-						token = "test"
+						token = "ff:70:81:a9:78:4d"
 						next_server = "192.168.1.1"
 						subnet = "255.255.255.0"
 
@@ -60,7 +60,7 @@ func TestAccResourceReservation(t *testing.T) {
 						description = "test reservation"
 						documentation = "test reservation"
 						duration = 86400
-						token = "test"
+						token = "ff:70:81:a9:78:4d"
 						subnet = "255.255.255.0"
 					}
 				`,
@@ -75,7 +75,7 @@ func TestAccResourceReservation(t *testing.T) {
 						description = "test reservation"
 						documentation = "test reservation"
 						duration = 86400
-						token = "test"
+						token = "ff:70:81:a9:78:4d"
 						subnet = "255.255.255.0"
 					}
 				`,

--- a/drpv4/resource_drp_stage.go
+++ b/drpv4/resource_drp_stage.go
@@ -76,6 +76,7 @@ func resourceStage() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Stage runner wait",
 				Optional:    true,
+				Computed:    true,
 			},
 			"tasks": {
 				Type:        schema.TypeList,

--- a/drpv4/resource_drp_workflow_test.go
+++ b/drpv4/resource_drp_workflow_test.go
@@ -41,7 +41,6 @@ func TestAccWorkflowResource(t *testing.T) {
 					resource.TestCheckResourceAttr("drp_workflow.test", "stages.#", "1"),
 					resource.TestCheckResourceAttr("drp_workflow.test", "stages.0", testWorkflowRandomName),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: fmt.Sprintf(`
@@ -69,7 +68,6 @@ func TestAccWorkflowResource(t *testing.T) {
 					resource.TestCheckResourceAttr("drp_workflow.test", "stages.#", "1"),
 					resource.TestCheckResourceAttr("drp_workflow.test", "stages.0", testWorkflowRandomName),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: fmt.Sprintf(`
@@ -97,7 +95,6 @@ func TestAccWorkflowResource(t *testing.T) {
 					resource.TestCheckResourceAttr("drp_workflow.test", "stages.#", "1"),
 					resource.TestCheckResourceAttr("drp_workflow.test", "stages.0", testWorkflowRandomName),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
- Fix wrong type for `add_parameters` in `drp_pool` resource
- Add tests to cover the previous change
- Fix `drp_stage` resource and change `runner_wait` to be a computed field
- Fix tests that were not expecting an empty plan because of `drp_stage` issue