### PR TITLE
fix: update state when machine is already released

### DIFF
--- a/drpv4/resource_drp_machine.go
+++ b/drpv4/resource_drp_machine.go
@@ -186,7 +186,7 @@ func resourceMachineRead(d *schema.ResourceData, m interface{}) error {
 	machineObject := mo.(*models.Machine)
 
 	d.Set("status", machineObject.PoolStatus)
-	d.Set("address", machineObject.Address)
+	d.Set("address", machineObject.Address.String())
 	d.Set("name", machineObject.Name)
 
 	return nil
@@ -215,6 +215,16 @@ func resourceMachineRelease(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Requires Pool")
 	}
 	log.Printf("[DEBUG] Releasing %s from %s", uuid, pool)
+
+	// Getting machine state
+	err := resourceMachineRead(d, m)
+	if err != nil {
+		return fmt.Errorf("failed to read machine data: %s", err)
+	}
+
+	if d.Get("status").(string) == "Free" {
+		return nil
+	}
 
 	pr := []*models.PoolResult{}
 	parms := map[string]interface{}{


### PR DESCRIPTION
Fixes the release process of the machine. If it is already released but state of terraform still has it `InUse`, it will simply remove the machine from terraform state, instead of call DRP API to release it from pool.