### PR TITLE
fix: Ignore subnet property for the reservation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 on:
   push:
+  pull_request:
 jobs:
   setup-drp:
     name: Setup DRP

--- a/drpv4/resource_drp_reservation.go
+++ b/drpv4/resource_drp_reservation.go
@@ -78,11 +78,6 @@ func resourceReservation() *schema.Resource {
 				Optional:    true,
 				Default:     "MAC",
 			},
-			"subnet": {
-				Type:        schema.TypeString,
-				Description: "Reservation subnet",
-				Optional:    true,
-			},
 			"token": {
 				Type:        schema.TypeString,
 				Description: "Reservation token",
@@ -140,7 +135,6 @@ func flattenReservation(d *schema.ResourceData, reservation *models.Reservation)
 
 	d.Set("scoped", reservation.Scoped)
 	d.Set("strategy", reservation.Strategy)
-	d.Set("subnet", reservation.Subnet)
 	d.Set("token", reservation.Token)
 
 	if reservation.Options != nil {
@@ -172,7 +166,6 @@ func expandReservation(d *schema.ResourceData) *models.Reservation {
 		Duration:      int32(d.Get("duration").(int)),
 		Scoped:        d.Get("scoped").(bool),
 		Strategy:      d.Get("strategy").(string),
-		Subnet:        d.Get("subnet").(string),
 		Token:         d.Get("token").(string),
 		Options:       expandReservationOptions(d.Get("options").([]interface{})),
 	}

--- a/drpv4/resource_drp_reservation_test.go
+++ b/drpv4/resource_drp_reservation_test.go
@@ -20,7 +20,6 @@ func TestAccResourceReservation(t *testing.T) {
 						documentation = "test reservation"
 						duration = 86400
 						token = "ff:70:81:a9:78:4d"
-						subnet = "255.255.255.0"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
@@ -29,7 +28,6 @@ func TestAccResourceReservation(t *testing.T) {
 					resource.TestCheckResourceAttr("drp_reservation.test", "documentation", "test reservation"),
 					resource.TestCheckResourceAttr("drp_reservation.test", "duration", "86400"),
 					resource.TestCheckResourceAttr("drp_reservation.test", "token", "ff:70:81:a9:78:4d"),
-					resource.TestCheckResourceAttr("drp_reservation.test", "subnet", "255.255.255.0"),
 				),
 			},
 			{
@@ -41,7 +39,6 @@ func TestAccResourceReservation(t *testing.T) {
 						duration = 86400
 						token = "ff:70:81:a9:78:4d"
 						next_server = "192.168.1.1"
-						subnet = "255.255.255.0"
 
 						options {
 							code = 1
@@ -61,7 +58,6 @@ func TestAccResourceReservation(t *testing.T) {
 						documentation = "test reservation"
 						duration = 86400
 						token = "ff:70:81:a9:78:4d"
-						subnet = "255.255.255.0"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
@@ -76,7 +72,6 @@ func TestAccResourceReservation(t *testing.T) {
 						documentation = "test reservation"
 						duration = 86400
 						token = "ff:70:81:a9:78:4d"
-						subnet = "255.255.255.0"
 					}
 				`,
 				ExpectError: regexp.MustCompile("Empty key not allowed"),


### PR DESCRIPTION
The `subnet` property is readonly for reservation and it gets updated by DRP itself, so does not makes any sense to manage it via Terraform.