### PR TITLE
fix: not found errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           curl -fsSL get.rebar.digital/stable | bash -s -- install --isolated --version=stable
       - name: Upload artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: drp
           path: |
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: drp
       - name: Set up Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf_version: ["1.4", "1.5", "1.6", "1.7"]
+        tf_version: ["1.7", "1.8", "1.9", "1.10", "1.11"]
       fail-fast: false
     needs: setup-drp
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,28 +14,11 @@ builds:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
     - darwin
-    - freebsd
     - linux
-    - openbsd
     - windows
   goarch:
-    - '386'
     - amd64
-    - arm
     - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-    - goos: darwin
-      goarch: arm
-    - goos: openbsd
-      goarch: '386'
-    - goos: openbsd
-      goarch: arm64
-    - goos: windows
-      goarch: arm
-    - goos: windows
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip

--- a/drpv4/resource_drp_machine.go
+++ b/drpv4/resource_drp_machine.go
@@ -185,7 +185,7 @@ func resourceMachineRead(d *schema.ResourceData, m interface{}) error {
 			return nil
 		} else {
 			log.Printf("[ERROR] [resourceMachineRead] Unable to get machine: %s", uuid)
-			return fmt.Errorf("Unable to get machine %s", uuid)
+			return fmt.Errorf("unable to get machine %s", uuid)
 		}
 	}
 	machineObject := mo.(*models.Machine)

--- a/drpv4/resource_drp_machine.go
+++ b/drpv4/resource_drp_machine.go
@@ -180,8 +180,13 @@ func resourceMachineRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Reading machine %s", uuid)
 	mo, err := cc.session.GetModel("machines", uuid)
 	if err != nil {
-		log.Printf("[ERROR] [resourceMachineRead] Unable to get machine: %s", uuid)
-		return fmt.Errorf("Unable to get machine %s", uuid)
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return nil
+		} else {
+			log.Printf("[ERROR] [resourceMachineRead] Unable to get machine: %s", uuid)
+			return fmt.Errorf("Unable to get machine %s", uuid)
+		}
 	}
 	machineObject := mo.(*models.Machine)
 

--- a/drpv4/resource_drp_machine_set_pool.go
+++ b/drpv4/resource_drp_machine_set_pool.go
@@ -95,11 +95,11 @@ func resourceMachineGetPool(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Reading machine %s", uuid)
 	mo, err := cc.session.GetModel("machines", uuid)
 	if err != nil {
-		if strings.HasSuffix(err.Error(), "Not Found") {
+		if strings.HasSuffix(err.Error(), "Unable to get machine") {
 			d.SetId("")
 			return nil
 		} else {
-			return fmt.Errorf("error reading param: %s", err)
+			return fmt.Errorf("error reading machine set pool: %s", err)
 		}
 	}
 	machineObject := mo.(*models.Machine)

--- a/drpv4/resource_drp_machine_set_pool.go
+++ b/drpv4/resource_drp_machine_set_pool.go
@@ -95,7 +95,7 @@ func resourceMachineGetPool(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Reading machine %s", uuid)
 	mo, err := cc.session.GetModel("machines", uuid)
 	if err != nil {
-		if strings.HasSuffix(err.Error(), "Unable to get machine") {
+		if strings.HasSuffix(err.Error(), "Unable to get machine") || strings.HasSuffix(err.Error(), "Not Found") {
 			d.SetId("")
 			return nil
 		} else {

--- a/drpv4/resource_drp_machine_set_pool.go
+++ b/drpv4/resource_drp_machine_set_pool.go
@@ -7,6 +7,7 @@ package drpv4
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/VictorLowther/jsonpatch2"
@@ -94,8 +95,12 @@ func resourceMachineGetPool(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Reading machine %s", uuid)
 	mo, err := cc.session.GetModel("machines", uuid)
 	if err != nil {
-		log.Printf("[ERROR] [resourceMachineRead] Unable to get machine: %s", uuid)
-		return fmt.Errorf("unable to get machine %s", uuid)
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return nil
+		} else {
+			return fmt.Errorf("error reading param: %s", err)
+		}
 	}
 	machineObject := mo.(*models.Machine)
 	d.Set("address", machineObject.Address.String())

--- a/drpv4/resource_drp_param.go
+++ b/drpv4/resource_drp_param.go
@@ -3,6 +3,7 @@ package drpv4
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -134,7 +135,12 @@ func resourceParamRead(d *schema.ResourceData, m interface{}) error {
 
 	po, err := c.session.GetModel("params", d.Id())
 	if err != nil {
-		return fmt.Errorf("error reading param: %s", err)
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return flattenParam(d, &models.Param{})
+		} else {
+			return fmt.Errorf("error reading param: %s", err)
+		}
 	}
 
 	return flattenParam(d, po.(*models.Param))

--- a/drpv4/resource_drp_pool.go
+++ b/drpv4/resource_drp_pool.go
@@ -1,7 +1,9 @@
 package drpv4
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"gitlab.com/rackn/provision/v4/models"
@@ -365,7 +367,12 @@ func resourcePoolRead(d *schema.ResourceData, m interface{}) error {
 
 	pool, err := c.session.GetModel("pools", d.Id())
 	if err != nil {
-		return err
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return flattenPool(d, &models.Pool{})
+		} else {
+			return fmt.Errorf("error reading pool: %s", err)
+		}
 	}
 
 	return flattenPool(d, pool.(*models.Pool))

--- a/drpv4/resource_drp_profile.go
+++ b/drpv4/resource_drp_profile.go
@@ -3,6 +3,7 @@ package drpv4
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"gitlab.com/rackn/provision/v4/models"
@@ -78,7 +79,12 @@ func resourceProfileRead(d *schema.ResourceData, m interface{}) error {
 
 	pr, err := c.session.GetModel("profiles", d.Id())
 	if err != nil {
-		return fmt.Errorf("error reading profile: %s", err)
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return flattenProfile(d, &models.Profile{})
+		} else {
+			return fmt.Errorf("error reading profile: %s", err)
+		}
 	}
 
 	return flattenProfile(d, pr.(*models.Profile))

--- a/drpv4/resource_drp_profile_param.go
+++ b/drpv4/resource_drp_profile_param.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"gitlab.com/rackn/provision/v4/models"
@@ -197,7 +198,12 @@ func resourceProfileParamRead(d *schema.ResourceData, m interface{}) error {
 
 	var p interface{}
 	if err := c.session.Req().UrlFor("profiles", profile, "params", name).Do(&p); err != nil {
-		return err
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	d.Set("name", name)

--- a/drpv4/resource_drp_stage.go
+++ b/drpv4/resource_drp_stage.go
@@ -3,6 +3,7 @@ package drpv4
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"gitlab.com/rackn/provision/v4/models"
@@ -243,7 +244,12 @@ func resourceStageRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := c.session.GetModel("stages", d.Id())
 	if err != nil {
-		return err
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return flattenStage(d, &models.Stage{})
+		} else {
+			return fmt.Errorf("error reading stage: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Stage read: %#v", res)

--- a/drpv4/resource_drp_subnet.go
+++ b/drpv4/resource_drp_subnet.go
@@ -3,6 +3,7 @@ package drpv4
 import (
 	"log"
 	"net"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"gitlab.com/rackn/provision/v4/models"
@@ -264,7 +265,13 @@ func resourceSubnetRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := c.session.GetModel("subnets", d.Id())
 	if err != nil {
-		return err
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			flattenSubnet(d, &models.Subnet{})
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	subnet := res.(*models.Subnet)

--- a/drpv4/resource_drp_task.go
+++ b/drpv4/resource_drp_task.go
@@ -3,6 +3,7 @@ package drpv4
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -310,7 +311,12 @@ func resourceTaskRead(d *schema.ResourceData, m interface{}) error {
 
 	to, err := c.session.GetModel("tasks", d.Id())
 	if err != nil {
-		return fmt.Errorf("error reading task: %s", err)
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return flattenTask(d, &models.Task{})
+		} else {
+			return fmt.Errorf("error reading task: %s", err)
+		}
 	}
 
 	return flattenTask(d, to.(*models.Task))

--- a/drpv4/resource_drp_template.go
+++ b/drpv4/resource_drp_template.go
@@ -3,6 +3,7 @@ package drpv4
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -105,7 +106,12 @@ func resourceTemplateRead(d *schema.ResourceData, m interface{}) error {
 
 	to, err := c.session.GetModel("templates", d.Id())
 	if err != nil {
-		return fmt.Errorf("error reading template: %s", err)
+		if strings.HasSuffix(err.Error(), "Not Found") {
+			d.SetId("")
+			return nil
+		} else {
+			return fmt.Errorf("error reading template: %s", err)
+		}
 	}
 
 	templateObject := to.(*models.Template)


### PR DESCRIPTION
Fixes the `Not Found` errors by marking the terraform resources as inexistents. It will force terraform to re-create them.