### PR TITLE
fix: patch return one object

### DIFF
--- a/drpv4/resource_drp_machine_set_pool.go
+++ b/drpv4/resource_drp_machine_set_pool.go
@@ -130,7 +130,7 @@ func resourceMachineSetPoolDelete(d *schema.ResourceData, m interface{}) error {
 
 	patch := jsonpatch2.Patch{{Op: "replace", Path: "/Pool", Value: "default"}}
 	reqm := cc.session.Req().Patch(patch).UrlFor("machines", uuid)
-	mr := []*models.Machine{}
+	mr := models.Machine{}
 	if err := reqm.Do(&mr); err != nil {
 		log.Printf("[DEBUG] POST error %+v | %+v", err, reqm)
 		return fmt.Errorf("error set pool %s: %s", "default", err)

--- a/drpv4/resource_drp_machine_set_pool.go
+++ b/drpv4/resource_drp_machine_set_pool.go
@@ -136,8 +136,7 @@ func resourceMachineSetPoolDelete(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("error set pool %s: %s", "default", err)
 	}
 
-	mc := mr[0]
-	if mc.Pool == "default" {
+	if mr.Pool == "default" {
 		d.SetId("")
 		return nil
 	} else {


### PR DESCRIPTION
The Patch method of /machines endpoint return just one object, not a list.