### PR TITLE
fix: pool add_parameters type assertion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/drpv4/resource_drp_pool.go
+++ b/drpv4/resource_drp_pool.go
@@ -223,12 +223,24 @@ func flattenPoolActions(actions *models.PoolTransitionActions) []map[string]inte
 
 	m := make([]map[string]interface{}, 1)
 	m[0] = map[string]interface{}{
-		"add_parameters":    actions.AddParameters,
+		"add_parameters":    map[string]interface{}{},
 		"add_profiles":      actions.AddProfiles,
 		"remove_parameters": actions.RemoveParameters,
 		"remove_profiles":   actions.RemoveProfiles,
 		"workflow":          actions.Workflow,
 	}
+
+	addParams := m[0]["add_parameters"].(map[string]interface{})
+
+	for k, v := range actions.AddParameters {
+		param, err := convertParamToString(v)
+		if err != nil {
+			panic(err)
+		}
+
+		addParams[k] = param
+	}
+
 	return m
 }
 

--- a/drpv4/resource_drp_pool.go
+++ b/drpv4/resource_drp_pool.go
@@ -295,6 +295,7 @@ func expandPoolActions(c *Config, actions []interface{}) *models.PoolTransitionA
 	a := actions[0].(map[string]interface{})
 
 	action := &models.PoolTransitionActions{
+		AddParameters:    map[string]interface{}{},
 		AddProfiles:      expandStringList(a["add_profiles"]),
 		RemoveParameters: expandStringList(a["remove_parameters"]),
 		RemoveProfiles:   expandStringList(a["remove_profiles"]),
@@ -302,7 +303,10 @@ func expandPoolActions(c *Config, actions []interface{}) *models.PoolTransitionA
 	}
 
 	for k, v := range a["add_parameters"].(map[string]interface{}) {
-		value, _ := convertParamToType(c, k, v.(string))
+		value, err := convertParamToType(c, k, v.(string))
+		if err != nil {
+			panic(err)
+		}
 		action.AddParameters[k] = value
 	}
 

--- a/drpv4/resource_drp_pool_test.go
+++ b/drpv4/resource_drp_pool_test.go
@@ -208,6 +208,48 @@ func TestAccResourcePool(t *testing.T) {
 				),
 				ExpectNonEmptyPlan: false,
 			},
+			{
+				Config: fmt.Sprintf(`
+					resource "drp_param" "test-param" {
+						name   = "%s-test"
+  						secure = false
+  						schema = {
+    						type = "boolean"
+  						}
+					}
+
+					resource "drp_pool" "test-param" {
+						pool_id = "%s-param"
+						description = "test pool"
+						documentation = "test pool"
+
+						allocate_actions {
+							workflow = "universal-hardware"
+							add_parameters = {
+								"universal/application" = "image-deploy"
+								"%s-test" = true
+							}
+						}
+
+						release_actions {
+							workflow = "universal-discover"
+							add_parameters = {
+								"universal/application" = "discover"
+								"%s-test" = false
+							}
+						}
+					}
+				`, testPoolRandomName, testPoolRandomName, testPoolRandomName, testPoolRandomName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("drp_pool.test-param", "allocate_actions.#", "1"),
+					resource.TestCheckResourceAttr("drp_pool.test-param", "allocate_actions.0.add_parameters.%", "2"),
+					resource.TestCheckResourceAttr("drp_pool.test-param", fmt.Sprintf(`allocate_actions.0.add_parameters.%s-test`, testPoolRandomName), "true"),
+					resource.TestCheckResourceAttr("drp_pool.test-param", "release_actions.#", "1"),
+					resource.TestCheckResourceAttr("drp_pool.test-param", "release_actions.0.add_parameters.%", "2"),
+					resource.TestCheckResourceAttr("drp_pool.test-param", fmt.Sprintf(`release_actions.0.add_parameters.%s-test`, testPoolRandomName), "false"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes the pool `add_parameters` to assert the correct type of the parameter.

## Example

The following example creates one parameter of type `boolean` and adds it to the actions in the pool:

```hcl
resource "drp_param" "test-param" {
	name   = "test"
  	secure = false
  	schema = {
    		type = "boolean"
  	}
}

resource "drp_pool" "test-param" {
	pool_id = "test-pool-param"
	description = "test pool"

	allocate_actions {
		workflow = "universal-hardware"
		add_parameters = {
                        "universal/application" = "image-deploy"
			"test" = true
		}
        }
	
        release_actions {
		workflow = "universal-discover"
		add_parameters = {
                        "universal/application" = "discover"
			"test" = false
		}
	}
}
```

When creating the pool, provider will try to convert the value to the proper value type (boolean, integer, etc.), if it can't will use string as default. This is needed because of DRP values handling in their API, as it will try to parse the provided value to its specific type.

When reading back from DRP API to do drift check, and because terraform limitation of map values needs to be of the same type, we need to convert the value to `string`.